### PR TITLE
fix vibrant database fontcolor white to black.

### DIFF
--- a/themes/puml-theme-vibrant.puml
+++ b/themes/puml-theme-vibrant.puml
@@ -24,7 +24,7 @@ skinparam participant {
 skinparam database {
     BackgroundColor 00FFFF
     BorderColor 454645
-    FontColor FFFFFF
+    FontColor 454645
 }
 
 skinparam entity {


### PR DESCRIPTION
The font color was the same as the background, and it was not visible, so I fixed it.

### before

```
@startuml

!include https://raw.githubusercontent.com/future-architect/puml-themes/master/themes/puml-theme-vibrant.puml

database ExampleDB

ExampleDB->ExampleDB

@enduml
```

![image](https://user-images.githubusercontent.com/7579796/117237226-6b4bed00-ae65-11eb-88d5-627ce85a084d.png)

### after

```
@startuml

!include https://raw.githubusercontent.com/gmidorii/puml-themes/master/themes/puml-theme-vibrant.puml

database ExampleDB

ExampleDB->ExampleDB

@enduml
```

![image](https://user-images.githubusercontent.com/7579796/117237258-81f24400-ae65-11eb-8da0-860089db692c.png)
